### PR TITLE
Improve CI/CD workflow for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,12 +30,16 @@ jobs:
         enable-cache: true
         cache-dependency-glob: "uv.lock"
 
+    - name: Install dependencies (FFTW + Open MPI)
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libfftw3-dev libopenmpi-dev
+
     - name: Setup Python virtual environment
       run: |
         uv python install ${{ matrix.python-version }} &&
         uv venv --python ${{ matrix.python-version }} &&
-        uv sync --active --all-groups --no-extra mpi
-#        uv sync --active --all-extras --all-groups &&
+        uv sync --active --all-extras --all-groups
 
     - name: Run tests
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,11 +47,10 @@ extra = [
 	"scikit-image>=0.24.0",
 	"upf-to-json>=0.9.5",
 ]
-# TODO: recover this when CI/CD config for MPI is done.
-#mpi = [
-#	"mpi4py",
-#	"mpi4py-fft",
-#]
+mpi = [
+	"mpi4py",
+	"mpi4py-fft",
+]
 
 [dependency-groups]
 docs = [
@@ -66,7 +65,7 @@ docs = [
 test = [
     "pytest>=8.3.5",
     "pytest-cov>=6.1.1",
-#    "pytest-mpi>=0.6", # TODO: recover this line when CI/CD config for MPI is done.
+    "pytest-mpi>=0.6",
 ]
 
 [project.urls]


### PR DESCRIPTION
Install `libfftw3-dev` and `libopenmpi-dev`, which are required by the project optional dendencies: `mpi4py` and `mpi4py-fft`.
The dev dependency `pytest-mpi` may also require `libopenmpi-dev`.