### PR TITLE
Feat(Ions): restraint the methods and attributes in Ions which inheritance from ASE

### DIFF
--- a/src/dftpy/ions.py
+++ b/src/dftpy/ions.py
@@ -1,6 +1,12 @@
 import numpy as np
 from ase import Atoms
+from ase.atom import Atom
+from ase.atoms import default
+from ase.symbols import symbols2numbers
+from ase.cell import Cell
+
 from dftpy.constants import Units
+
 
 class Ions(Atoms):
     """Ions object based on `ase.Atoms <https://wiki.fysik.dtu.dk/ase/ase/atoms.html>`_
@@ -14,78 +20,203 @@ class Ions(Atoms):
              - celldisp : Bohr
 
     """
-    def __init__(self,
-            symbols=None,
-            positions=None,
-            numbers=None,
-            tags=None,
-            momenta=None,
-            masses=None,
-            magmoms=None,
-            charges=None,
-            scaled_positions=None,
-            cell=None,
-            pbc=None,
-            celldisp=None,
-            constraint=None,
-            calculator=None,
-            info=None,
-            velocities=None,
-            units = 'au'):
+
+    allowed_methods = [
+        "new_array",
+        "set_cell",
+        "set_celldisp",
+        "get_celldisp",
+        "set_tags",
+        "get_tags",
+        "set_array",
+        "set_initial_magnetic_moments",
+        "get_initial_magnetic_moments",
+        "set_initial_charges",
+        "get_initial_charges",
+        "get_ncharges",
+        "set_charges",
+        "get_charges",
+        "strf",
+        "istrf",
+        "symbols_uniq",
+        "nat",
+        "zval",
+        "get_chemical_symbols",
+        "set_pbc",
+        "set_positions",
+        "get_positions",
+        "get_ncharges",
+        "to_ase",
+        "from_ase",
+        "has",
+    ]
+    allowed_attributes = [
+        "init_options",
+        "symbols",
+        "positions",
+        "numbers",
+        "tags",
+        "magmoms",
+        "charges",
+        "scaled_positions",
+        "cell",
+        "celldisp",
+        "info",
+        "velocities",
+        "get_ncharges",
+        "get_charges",
+        "set_charges",
+        "strf",
+        "istrf",
+        "symbols_uniq",
+        "nat",
+        "zval",
+        "arrays",
+        "pbc",
+    ]
+
+    def __getattribute__(self, name):
+        attr = object.__getattribute__(self, name)
+        is_special = (name.startswith("__") and name.endswith("__")) or name.startswith(
+            "_"
+        )
+
+        if callable(attr):
+            if not is_special and name not in Ions.allowed_methods:
+                raise AttributeError(
+                    f"Unsupported method `{name}` in {self.__class__.__name__}. Please use 'to_ase' method to convert from ASE object."
+                )
+        else:
+            if not is_special and name not in Ions.allowed_attributes:
+                raise AttributeError(f"Unsupported attribute `{name}` in {self.__class__.__name__}. Please use 'to_ase' method to convert from ASE object.")
+        return attr
+
+    def __init__(
+        self,
+        symbols=None,
+        positions=None,
+        numbers=None,
+        tags=None,
+        magmoms=None,
+        charges=None,
+        scaled_positions=None,
+        cell=None,
+        celldisp=None,
+        info=None,
+    ):
+
+        if hasattr(symbols, "get_positions") or (
+            isinstance(symbols, (list, tuple))
+            and len(symbols) > 0
+            and isinstance(symbols[0], Atom)
+        ):
+            raise TypeError("Please use 'from_ase' method to convert from ASE object.")
 
         self.init_options = locals()
-        for k in ['__class__', 'self'] :
+        for k in ["__class__", "self"]:
             self.init_options.pop(k, None)
 
-        super().__init__(
-            symbols=symbols,
-            positions=positions,
-            numbers=numbers,
-            tags=tags,
-            momenta=momenta,
-            masses=masses,
-            magmoms=magmoms,
-            charges=charges,
-            scaled_positions=scaled_positions,
-            cell=cell,
-            pbc=pbc,
-            celldisp=celldisp,
-            constraint=constraint,
-            calculator=calculator,
-            info=info,
-            velocities=velocities)
+        # Init ASE Atoms
+        self._cellobj = Cell.new()
+        self.arrays = {}
+        if symbols is not None and numbers is not None:
+            raise TypeError('Use only one of "symbols" and "numbers".')
+        if symbols is not None:
+            numbers = symbols2numbers(symbols)
+        elif numbers is None:
+            if positions is not None:
+                natoms = len(positions)
+            elif scaled_positions is not None:
+                natoms = len(scaled_positions)
+            else:
+                natoms = 0
+            numbers = np.zeros(natoms, int)
+        self.new_array("numbers", numbers, int)
 
-        if units != 'au' :
-            self.convert_units()
+        if self.numbers.ndim != 1:
+            raise ValueError('"numbers" must be 1-dimensional.')
+
+        if cell is None:
+            cell = np.zeros((3, 3))
+        self.set_cell(cell)
+
+        if celldisp is None:
+            celldisp = np.zeros(shape=(3, 1))
+        self.set_celldisp(celldisp)
+
+        if positions is None:
+            if scaled_positions is None:
+                positions = np.zeros((len(self.arrays["numbers"]), 3))
+            else:
+                assert self.cell.rank == 3
+                positions = np.dot(scaled_positions, self.cell)
+        else:
+            if scaled_positions is not None:
+                raise TypeError('Use only one of "positions" and "scaled_positions".')
+        self.new_array("positions", positions, float, (3,))
+        self.set_tags(default(tags, 0))
+        self.set_initial_magnetic_moments(default(magmoms, 0.0))
+        self.set_initial_charges(default(charges, 0.0))
+        self._pbc = np.array([True, True, True], dtype=bool)
+        self._constraints = None
+
+        if info is None:
+            self.info = {}
+        else:
+            self.info = dict(info)
+
+        # super().__init__(
+        #     symbols=symbols,
+        #     positions=positions,
+        #     numbers=numbers,
+        #     tags=tags,
+        #     momenta=None,
+        #     masses=None,
+        #     magmoms=magmoms,
+        #     charges=charges,
+        #     scaled_positions=scaled_positions,
+        #     cell=cell,
+        #     pbc=True,
+        #     celldisp=celldisp,
+        #     constraint=None,
+        #     calculator=None,
+        #     info=info,)
 
     def to_ase(self):
-        atoms = self.copy()
-        atoms.convert_units(backward=True)
+        atoms = Atoms(
+            symbols=self.symbols,
+            positions=self.get_positions() * Units.Bohr,
+            # numbers=self.numbers,d
+            tags=self.get_tags(),
+            magmoms=self.get_initial_magnetic_moments(),
+            charges=self.get_initial_charges(),
+            cell=self.cell.array * Units.Bohr,
+            celldisp=self.get_celldisp() * Units.Bohr,
+            info=self.info,
+            pbc=self.pbc,
+        )
         return atoms
 
     @staticmethod
-    def from_ase(atoms):
-        ions = Ions(atoms, units = 'ase')
+    def from_ase(atoms: Atoms):
+        ions = Ions(
+            symbols=atoms.symbols,
+            positions=atoms.get_positions() / Units.Bohr,
+            # numbers=atoms.numbers,
+            tags=atoms.get_tags(),
+            magmoms=atoms.get_initial_magnetic_moments(),
+            charges=atoms.get_initial_charges(),
+            cell=atoms.cell,
+            celldisp=atoms.get_celldisp() / Units.Bohr,
+            info=atoms.info,
+        )
         return ions
-
-    def convert_units(self, backward = False):
-        """"Convert the units to atomic units or ase units."""
-        if not backward :
-            self.cell.array[:] /= Units.Bohr
-            if self.has('positions'):
-                self.positions[:] /= Units.Bohr
-            self._celldisp /= Units.Bohr
-        else :
-            self.cell.array[:] *= Units.Bohr
-            if self.has('positions'):
-                self.positions[:] *= Units.Bohr
-            self._celldisp *= Units.Bohr
 
     def get_ncharges(self):
         """Get total number of charges."""
-        if not self.has('initial_charges'):
+        if not self.has("initial_charges"):
             raise AttributeError("Please call 'set_charges' before use 'charges'.")
-        return self.arrays['initial_charges'].sum()
+        return self.arrays["initial_charges"].sum()
 
     def get_charges(self):
         """Get the atomic charges."""
@@ -95,37 +226,41 @@ class Ions(Atoms):
         """Set the atomic charges."""
         if isinstance(charges, dict):
             values = []
-            for s in self.symbols :
-                if s not in charges :
+            for s in self.symbols:
+                if s not in charges:
                     raise AttributeError(f"{s} not in the charges")
                 values.append(charges[s])
             charges = values
-        elif isinstance(charges, (float,int)):
-            charges = np.ones(self.nat)*charges
+        elif isinstance(charges, (float, int)):
+            charges = np.ones(self.nat) * charges
         self.set_initial_charges(charges=charges)
 
     @property
     def charges(self):
         """Get the atomic charges."""
-        if not self.has('initial_charges'):
+        if not self.has("initial_charges"):
             raise AttributeError("Please call 'set_charges' before use 'charges'.")
-        return self.arrays['initial_charges']
+        return self.arrays["initial_charges"]
 
     @charges.setter
     def charges(self, value):
         """Set the atomic charges."""
-        if not self.has('initial_charges'):
+        if not self.has("initial_charges"):
             raise AttributeError("Please call 'set_charges' before use 'charges'.")
-        self.arrays['initial_charges'][:] = value
+        self.arrays["initial_charges"][:] = value
 
     def strf(self, reciprocal_grid, iatom):
         """Returns the Structure Factor associated to i-th ion."""
-        a = np.exp(-1j * np.einsum("lijk,l->ijk", reciprocal_grid.g, self.positions[iatom]))
+        a = np.exp(
+            -1j * np.einsum("lijk,l->ijk", reciprocal_grid.g, self.positions[iatom])
+        )
         return a
 
     def istrf(self, reciprocal_grid, iatom):
         """Returns the Structure-Factor-like property associated to i-th ion."""
-        a = np.exp(1j * np.einsum("lijk,l->ijk", reciprocal_grid.g, self.positions[iatom]))
+        a = np.exp(
+            1j * np.einsum("lijk,l->ijk", reciprocal_grid.g, self.positions[iatom])
+        )
         return a
 
     @property
@@ -145,12 +280,15 @@ class Ions(Atoms):
         symbols = self.get_chemical_symbols()
         try:
             self.charges[0]
-        except Exception :
+        except Exception:
             return zval
 
-        for k in zval :
+        for k in zval:
             for i in range(self.nat):
-                if symbols[i] == k :
+                if symbols[i] == k:
                     zval[k] = self.charges[i]
                     break
         return zval
+    
+    def set_positions(self, newpositions):
+        self.set_array('positions', newpositions, shape=(3,))

--- a/tests/unit/test_ions.py
+++ b/tests/unit/test_ions.py
@@ -1,0 +1,112 @@
+import pytest
+import numpy as np
+from ase import Atoms
+from dftpy.ions import Ions
+from dftpy.constants import Units
+
+def test_ions_initialization():
+    symbols = ["H", "He"]
+    positions = [[0, 0, 0], [1, 1, 1]]
+    cell = np.eye(3) * 10
+    ions = Ions(symbols=symbols, positions=positions, cell=cell)
+
+    assert ions.nat == 2
+    assert ions.symbols_uniq.tolist() == ["H", "He"]
+    assert np.allclose(ions.get_positions(), positions)
+    assert np.allclose(ions.cell.array, cell)
+
+
+def test_ions_set_charges():
+    symbols = ["H", "He"]
+    positions = [[0, 0, 0], [1, 1, 1]]
+    ions = Ions(symbols=symbols, positions=positions)
+
+    charges = [1.0, 2.0]
+    ions.set_charges(charges)
+    assert np.allclose(ions.get_charges(), charges)
+
+    with pytest.raises(AttributeError):
+        ions.set_charges({"Li": 3.0})
+
+
+def test_ions_to_ase():
+    symbols = ["H", "He"]
+    positions = [[0, 0, 0], [1, 1, 1]]
+    cell = np.eye(3) * 10
+    ions = Ions(symbols=symbols, positions=positions, cell=cell)
+
+    ase_atoms = ions.to_ase()
+    assert isinstance(ase_atoms, Atoms)
+    assert ase_atoms.get_chemical_symbols() == symbols
+    assert np.allclose(ase_atoms.get_positions(), np.array(positions) * Units.Bohr)
+    assert np.allclose(ase_atoms.cell, cell * Units.Bohr)
+
+
+def test_ions_from_ase():
+    symbols = ["H", "He"]
+    positions = [[0, 0, 0], [1, 1, 1]]
+    cell = np.eye(3) * 10
+    ase_atoms = Atoms(symbols=symbols, positions=positions, cell=cell)
+
+    ions = Ions.from_ase(ase_atoms)
+    assert ions.nat == 2
+    assert ions.symbols_uniq.tolist() == ["H", "He"]
+    assert np.allclose(ions.get_positions(), np.array(positions) / Units.Bohr)
+    assert np.allclose(ions.cell.array, cell/ Units.Bohr)
+
+
+def test_ions_get_ncharges():
+    symbols = ["H", "He"]
+    positions = [[0, 0, 0], [1, 1, 1]]
+    ions = Ions(symbols=symbols, positions=positions)
+
+    charges = [1.0, 2.0]
+    ions.set_charges(charges)
+    assert ions.get_ncharges() == sum(charges)
+
+
+def test_ions_zval_property():
+    symbols = ["H", "He"]
+    positions = [[0, 0, 0], [1, 1, 1]]
+    ions = Ions(symbols=symbols, positions=positions)
+
+    charges = [1.0, 2.0]
+    ions.set_charges(charges)
+    zval = ions.zval
+    assert zval["H"] == 1.0
+    assert zval["He"] == 2.0
+
+def test_ions_input_from_atoms():
+    symbols = ["H", "He"]
+    positions = [[0, 0, 0], [1, 1, 1]]
+    cell = np.eye(3) * 10
+    ase_atoms = Atoms(symbols=symbols, positions=positions, cell=cell)
+
+    ions = Ions(ase_atoms)
+    assert ions.nat == 2
+    assert ions.symbols_uniq.tolist() == ["H", "He"]
+    assert np.allclose(ions.get_positions(), np.array(positions) / Units.Bohr)
+    assert np.allclose(ions.cell.array, cell / Units.Bohr)
+
+
+def test_ions_invalid_methods_and_attributes():
+    symbols = ["H", "He"]
+    positions = [[0, 0, 0], [1, 1, 1]]
+    ions = Ions(symbols=symbols, positions=positions)
+
+    with pytest.raises(AttributeError):
+        ions.unsupported_method()
+
+    with pytest.raises(AttributeError):
+        _ = ions.unsupported_attribute
+
+def test_ions_repeat():
+    symbols = ["H", "He"]
+    positions = [[0, 0, 0], [1, 1, 1]]
+    cell = np.eye(3) * 10
+    ions = Ions(symbols=symbols, positions=positions, cell=cell)
+
+    repeated_ions = ions.repeat((2,1,1))
+    positions_repeated = [[0, 0, 0], [1, 1, 1], [10, 0, 0], [11, 1, 1]]
+    assert repeated_ions.nat == 4
+    assert np.allclose(repeated_ions.get_positions(), positions_repeated)


### PR DESCRIPTION
# Goal
 DFTpy uses atomic units (A.U.), while ASE has its own unit system. To prevent errors, the Ions class must:

- Restrict public methods/attributes to enforce unit consistency.
- Provide explicit conversion methods (e.g., to_ase(), from_ase()).